### PR TITLE
- changed nameid_format to not required, since the bbc assertion resp…

### DIFF
--- a/lib/Net/SAML2/Protocol/AuthnRequest.pm
+++ b/lib/Net/SAML2/Protocol/AuthnRequest.pm
@@ -76,8 +76,7 @@ sub as_xml {
             ),
             $x->NameIDPolicy(
                 $samlp,
-                { AllowCreate => 'true',
-                  Format => $self->nameid_format },
+                { Format => $self->nameid_format },
             ),
             defined($self->authn_context) ? $x->RequestedAuthnContext(
                 $samlp,

--- a/lib/Net/SAML2/Protocol/LogoutRequest.pm
+++ b/lib/Net/SAML2/Protocol/LogoutRequest.pm
@@ -37,7 +37,7 @@ Arguments:
 
 has 'session'       => (isa => NonEmptySimpleStr, is => 'ro', required => 1);
 has 'nameid'        => (isa => NonEmptySimpleStr, is => 'ro', required => 1);
-has 'nameid_format' => (isa => NonEmptySimpleStr, is => 'ro', required => 1);
+has 'nameid_format' => (is => 'ro', required => 0);
 has 'issuer'        => (isa => Uri, is => 'ro', required => 1, coerce => 1);
 has 'destination'   => (isa => Uri, is => 'ro', required => 1, coerce => 1);
 
@@ -84,6 +84,7 @@ sub as_xml {
             $samlp,
             { ID => $self->id,
               IssueInstant => $self->issue_instant, 
+              Destination => $self->destination,
               Version => '2.0' },
             $x->Issuer(
                 $saml,
@@ -91,9 +92,7 @@ sub as_xml {
             ),
             $x->NameID(
                 $saml,
-                { Format => $self->nameid_format,
-                  NameQualifier => $self->destination,
-                  SPNameQualifier => $self->issuer },
+                {},
                 $self->nameid,
             ),
             $x->SessionIndex(

--- a/lib/Net/SAML2/SP.pm
+++ b/lib/Net/SAML2/SP.pm
@@ -197,11 +197,10 @@ parameter involved - typically SAMLRequest.
 =cut
 
 sub sso_redirect_binding {
-    my ($self, $idp, $param, $destination) = @_;
+    my ($self, $idp, $param) = @_;
 
-    my $url = $destination // $idp->sso_url('urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect');    
     my $redirect = Net::SAML2::Binding::Redirect->new(
-        url   => $url,
+        url   => $idp->sso_url('urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'),
         cert  => $idp->cert('signing'),
         key   => $self->cert,
         param => $param,


### PR DESCRIPTION
…onse doesnt add it to the nameid node.
- pass in destination when creating the logout request
- revert a previous change of passing in a custom slo_url
